### PR TITLE
EUREKA-372: add mapping for orders.bypass-acquisition-units

### DIFF
--- a/mappings-overrides.json
+++ b/mappings-overrides.json
@@ -419,6 +419,11 @@
     "action": "execute",
     "type": "procedural"
   },
+  "orders.bypass-acquisition-units": {
+    "resource": "Orders Bypass-Acquisition-Units",
+    "action": "execute",
+    "type": "procedural"
+  },
   "ui-eholdings.app.enabled": {
     "resource": "UI-Eholdings App Enabled",
     "action": "view",
@@ -911,8 +916,8 @@
   },
   "invoices.bypass-acquisition-units": {
     "resource": "Bypass acquisition units checks",
-    "action": "manage",
-    "type": "data"
+    "action": "execute",
+    "type": "procedural"
   },
   "ui-tenant-settings.settings.locale": {
     "resource": "UI-Tenant-Settings Settings Locale",


### PR DESCRIPTION
## Purpose
Add capability for `orders.bypass-acquisition-units` permission to be absent in the system
US: [EUREKA-372](https://folio-org.atlassian.net/browse/EUREKA-372)
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->

## Approach
Add mapping for `orders.bypass-acquisition-units`
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Testing

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/0d53e918-bf36-440a-9d9b-1316de635253">

