### PR TITLE
EUREKA-421: add mapping for "ui-users.view-reading-room-access" and "ui-users.edit-reading-room-access"

### DIFF
--- a/mappings-overrides.json
+++ b/mappings-overrides.json
@@ -784,6 +784,16 @@
     "action": "view",
     "type": "data"
   },
+  "ui-users.view-reading-room-access": {
+    "resource": "UI-Users View-Reding-Room-Access",
+    "action": "view",
+    "type": "data"
+  },
+  "ui-users.edit-reading-room-access": {
+    "resource": "UI-Users Edit-Reding-Room-Access",
+    "action": "view",
+    "type": "data"
+  },
   "ui-harvester-admin.read-jobs": {
     "resource": "UI-Harvester-Admin Jobs",
     "action": "view",


### PR DESCRIPTION
## Purpose
Permissions `ui-users.view-reading-room-access`, `ui-users.edit-reading-room-access` be registered in the system.
US: [EUREKA-421](https://folio-org.atlassian.net/browse/EUREKA-421)

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->

## Approach
Register the permissions
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
