### PR TITLE
EUREKA-426: add mapping for ui-users patron related permissions

### DIFF
--- a/mappings-overrides.json
+++ b/mappings-overrides.json
@@ -719,6 +719,21 @@
     "action": "manage",
     "type": "data"
   },
+  "ui-users.view-patron-notice-print-jobs": {
+    "resource": "UI-Users View-Patron-Notice-Print-Jobs",
+    "action": "manage",
+    "type": "data"
+  },
+  "ui-users.patron-pre-registrations-view": {
+    "resource": "UI-Users Patron-Pre-Registrations-View",
+    "action": "manage",
+    "type": "data"
+  },
+  "ui-users.remove-patron-notice-print-jobs": {
+    "resource": "UI-Users Remove-Patron-Notice-Print-Jobs",
+    "action": "manage",
+    "type": "data"
+  },
   "ui-users.loans.renew": {
     "resource": "UI-Users Loans Renew",
     "action": "execute",


### PR DESCRIPTION
## Purpose
Capabilities `ui-users.view-patron-notice-print-jobs`, `ui-users.patron-pre-registrations-view`, `ui-users.remove-patron-notice-print-jobs` be registered in the system.
US: [EUREKA-426](https://folio-org.atlassian.net/browse/EUREKA-426)
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->

## Approach
Register `ui-users.view-patron-notice-print-jobs`, `ui-users.patron-pre-registrations-view`, `ui-users.remove-patron-notice-print-jobs` in mapping overrides.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
