### PR TITLE
EUREKA-713: Add absent permission mapping

### DIFF
--- a/mappings-overrides.json
+++ b/mappings-overrides.json
@@ -209,6 +209,11 @@
     "action": "edit",
     "type": "data"
   },
+  "patron-pin.validate": {
+    "resource": "Patron-Pin Validate",
+    "action": "execute",
+    "type": "procedural"
+  },
   "users.read.basic": {
     "resource": "Users Basic-Information",
     "action": "view",


### PR DESCRIPTION
## Feature
https://folio-org.atlassian.net/browse/EUREKA-713

## Purpose
'patron-pin.validate' conflicts with 'patron-pin.post', configuring it manually will resolve the problem.

## Approach

- Add conflicting permission mapping to 'mappings-overrides.json'
